### PR TITLE
Adding session type section and event recap content

### DIFF
--- a/sessions/README.md
+++ b/sessions/README.md
@@ -1,0 +1,7 @@
+# Sessions
+On this section you will find the most common type of sessions the type of session that is commonly hosted during an AWS User Group.
+
+## Session types
+- [Talk](/sessions/talk.md)
+- [Lightning Talk](/sessions/lightning-talk.md)
+- [Event recap](/sessions/event-recap.md)

--- a/sessions/event-recap.md
+++ b/sessions/event-recap.md
@@ -1,0 +1,19 @@
+# Event recap
+
+## Introduction
+
+The event recap consists on sharing the highlights of an AWS event that happened recently in the region. You can do it for AWS Summit, AWS Cloud Experience, AWS Community Day, or any other events that may be relevant to share with your community.
+
+## Objective
+
+The purpose of the recap sessions is to bring your community closer to AWS events and show the value that an event can have on your personal and career growth.
+
+## Session format
+
+This session is flexible to be done in multiple ways, some of the formats we can suggest:
+
+* **Recap session**: Prepare a few slides with the highlights of the event, sharing informations such as: how many people participated in the event, how the venue was organized, highlight important sessions or highlight community sessions. 
+
+* **Roundtable**: organize a roundtable with 3-5 participants to discuss about their own experience on the event, with a mediator asking questions and promoting the spontaneous discussion between the participants and the public.
+
+* **Q&A**: Open discussion with the community, especially with those who were present at the event, sharing experiences, what they like more and less, which session was your favorite. It's important to give people who haven't been there a chance to ask questions they might have about the event.

--- a/sessions/lightning-talk.md
+++ b/sessions/lightning-talk.md
@@ -1,0 +1,13 @@
+# Lightning talk
+
+## Introduction
+
+_TO-DO_
+
+## Objective
+
+_TO-DO_
+
+## Session format
+
+_TO-DO_

--- a/sessions/talk.md
+++ b/sessions/talk.md
@@ -1,0 +1,13 @@
+# Talk
+
+## Introduction
+
+_TO-DO_
+
+## Objective
+
+_TO-DO_
+
+## Session format
+
+_TO-DO_


### PR DESCRIPTION
I've created a new section called "sessions" to add the usual session types is hosted by AWS UG. Within the session, I added the content for Event recap, and the draft for sessions and lightning talk (seems like a good work to be done by you @Fabrimonteiro 👀👀)


